### PR TITLE
Add decorator for Sanic exception views

### DIFF
--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -1,6 +1,8 @@
 # pylint:disable=too-few-public-methods,import-error,line-too-long
 
 import sys
+from functools import wraps
+
 import raven
 from sanic.handlers import ErrorHandler
 from sanic import exceptions as sanic_exceptions
@@ -31,3 +33,20 @@ class SanicSentryErrorHandler(ErrorHandler):
         )
 
         return super(SanicSentryErrorHandler, self).default(request, exception)
+
+    def intercept_exception(self, function):
+        """
+        Decorator for Sanic exception views.
+        Example:
+            >> @app.exception([Exception, ])
+            >> @sentry_client.intercept_exception
+            >> def handle_exception(request, exception):
+            >>     pass
+        """
+
+        @wraps(function)
+        def wrapped_view_function(request, exception):
+            self.default(request, exception)
+            return function(request, exception)
+
+        return wrapped_view_function


### PR DESCRIPTION
Hey! I found your library and I think that your implementation is really cool, thanks for sharing it.

I would like to add a decorator for Sanic exception handlers:

```python
@app.exception([ValueError, TypeError, Exception])
@sentry_client.intercept_exception
def handle_http_500(request, exception):
    return response.json({"description": "custom error"}, status=500)
```

Please let me know If you like this solution. I would like to contribute and start using your library asap. 👍 