### PR TITLE
Nicer code + Handle exc_info is None

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout venv

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Installation
 
 **sanic-sentry-error-handler** should be installed using pip: ::
 
-    pip install sanic-sentry-error-handlert
+    pip install sanic-sentry-error-handler
 
 
 Usage

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -22,7 +22,7 @@ class SanicSentryErrorHandler(ErrorHandler):
     def default(self, request, exception):
         if not isinstance(exception, self.exceptions_to_ignore):
             exc_info = sys.exc_info()
-            if not exc_info:
+            if not exc_info or all((not x for x in exc_info)):
                 exc_info = (type(exception), exception, exception.__traceback__)
 
             extra = dict()

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -21,9 +21,7 @@ class SanicSentryErrorHandler(ErrorHandler):
 
     def default(self, request, exception):
         if not isinstance(exception, self.exceptions_to_ignore):
-            exc_info = sys.exc_info()
-            if not exc_info or all((not x for x in exc_info)):
-                exc_info = (type(exception), exception, exception.__traceback__)
+            exc_info = (type(exception), exception, exception.__traceback__)
 
             extra = dict()
             if request is not None:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     long_description=readme,
     platforms=('Any'),
     keywords=['sanic', 'sentry'],
-
     author='Eran Kampf',
     url='https://github.com/ekampf/sanic-sentry-error-handler',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
 
 setup(
     name='sanic-sentry-error-handler',
-    version='0.1.4',
+    version='0.1.5',
     license='MIT',
     description='Sanic error handlert that integrates with Sentry',
     long_description=readme,


### PR DESCRIPTION
`sys.exc_info()` is not guaranteed to have value when adding custom scenic exception handlers because code gets executed in a different frame