### PR TITLE
Safely render request into an extras dictionary

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,6 @@
-pylint==1.8.2
-pytest==3.3.2
-pytest-mock==1.6.3
-pytest-sanic==0.1.6
-pytest-sugar==0.9.0
+pylint~=2.1.1
+pytest~=3.8.0
+pytest-mock~=1.10.0
+pytest-sanic~=0.1.13
+pytest-sugar~=0.9.1
 Flask==1.0.2

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -39,9 +39,9 @@ class SanicSentryErrorHandler(ErrorHandler):
         return dict(
             url=safe_getattr(request, "url"),
             method=safe_getattr(request, "method"),
-            headers=safe_getattr(request, "request.headers"),
+            headers=safe_getattr(request, "headers"),
             body=safe_getattr(request, "body"),
-            query_string=safe_getattr(request, "query_string")
+            query_string=safe_getattr(request, "query_string"),
         )
 
     def intercept_exception(self, function):

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -36,6 +36,7 @@ class SanicSentryErrorHandler(ErrorHandler):
         return super(SanicSentryErrorHandler, self).default(request, exception)
 
     def _request_debug_info(self, request):
+        # pylint:disable=no-self-use
         return dict(
             url=safe_getattr(request, "url"),
             method=safe_getattr(request, "method"),

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -1,6 +1,5 @@
 # pylint:disable=too-few-public-methods,import-error,line-too-long
 
-import sys
 from functools import wraps
 
 import raven
@@ -9,7 +8,7 @@ from sanic.handlers import ErrorHandler
 from sanic import exceptions as sanic_exceptions
 
 
-def safe_getattr(self, request, attr_name, default=None):
+def safe_getattr(request, attr_name, default=None):
     # pylint:disable=bare-except
     try:
         return getattr(request, attr_name, default)

--- a/sanic_sentry/__init__.py
+++ b/sanic_sentry/__init__.py
@@ -9,6 +9,14 @@ from sanic.handlers import ErrorHandler
 from sanic import exceptions as sanic_exceptions
 
 
+def safe_getattr(self, request, attr_name, default=None):
+    # pylint:disable=bare-except
+    try:
+        return getattr(request, attr_name, default)
+    except:
+        return default
+
+
 class SanicSentryErrorHandler(ErrorHandler):
     DEFAULT_EXCEPTIONS_TO_IGNORE = (sanic_exceptions.NotFound,)
 
@@ -29,18 +37,12 @@ class SanicSentryErrorHandler(ErrorHandler):
 
     def _request_debug_info(self, request):
         return dict(
-            url=self._safe_getattr(request, "url"),
-            method=self._safe_getattr(request, "method"),
-            headers=self._safe_getattr(request, "request.headers"),
-            body=self._safe_getattr(request, "body"),
-            query_string=self._safe_getattr(request, "query_string")
+            url=safe_getattr(request, "url"),
+            method=safe_getattr(request, "method"),
+            headers=safe_getattr(request, "request.headers"),
+            body=safe_getattr(request, "body"),
+            query_string=safe_getattr(request, "query_string")
         )
-
-    def _safe_getattr(self, request, attr_name, default=None):
-        try:
-            return getattr(request, attr_name, default)
-        except:
-            return default
 
     def intercept_exception(self, function):
         """

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
 
 setup(
     name='sanic-sentry-error-handler',
-    version='0.1.6',
+    version='0.1.7',
     license='MIT',
     description='Sanic error handlert that integrates with Sentry',
     long_description=readme,


### PR DESCRIPTION
On incomplete request (like in RequestTimeout case) fetching data from request variable can result in an error